### PR TITLE
Alternative constructor for non-TLS, local endpoints

### DIFF
--- a/google-cloud/src/tests/datastore.rs
+++ b/google-cloud/src/tests/datastore.rs
@@ -15,8 +15,7 @@ macro_rules! assert_ok {
 }
 
 async fn setup_client() -> Result<datastore::Client, datastore::Error> {
-    let creds = super::load_creds();
-    datastore::Client::from_credentials(env!("GCP_TEST_PROJECT"), creds).await
+    datastore::Client::new_test_client("test-project").await
 }
 
 #[tokio::test]

--- a/google-cloud/src/vision/api/google.cloud.vision.v1.rs
+++ b/google-cloud/src/vision/api/google.cloud.vision.v1.rs
@@ -1313,7 +1313,9 @@ pub mod text_annotation {
     }
     pub mod detected_break {
         /// Enum to denote the type of break found. New line, space etc.
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[derive(
+            Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,
+        )]
         #[repr(i32)]
         pub enum BreakType {
             /// Unknown break label type.
@@ -1780,7 +1782,9 @@ pub mod face_annotation {
         /// Left and right are defined from the vantage of the viewer of the image
         /// without considering mirror projections typical of photos. So, `LEFT_EYE`,
         /// typically, is the person's right eye.
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[derive(
+            Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration,
+        )]
         #[repr(i32)]
         pub enum Type {
             /// Unknown face landmark detected. Should not be filled.


### PR DESCRIPTION
Run a `datastore` emulator on `localhost:8077`, then run `cargo test` to run integration tests without hitting GCP.


To use this in an existing project (even temporarily for testing)

```
google-cloud = { git = "https://github.com/descarteslabs/google-cloud-rs", branch = 'endpoint', features = ["datastore"] }
```